### PR TITLE
set ellipsize of labels and menuItems to Pango.EllipsizeMode.MIDDLE

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const GObject = imports.gi.GObject;
+const Pango = imports.gi.Pango;
 
 const AudioOutputSubMenu = GObject.registerClass({
     GTypeName: 'ASAudioOutputSubMenu',
@@ -24,6 +25,7 @@ const AudioOutputSubMenu = GObject.registerClass({
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
 		this.menu.addMenuItem(item);
+		this.label.clutter_text.set_ellipsize(Pango.EllipsizeMode.MIDDLE);
 	}
 
 	_updateDefaultSink() {
@@ -48,6 +50,7 @@ const AudioOutputSubMenu = GObject.registerClass({
 			if (sink === defsink)
 				continue;
 			item = new PopupMenu.PopupMenuItem(sink.get_description());
+			item.label.clutter_text.set_ellipsize(Pango.EllipsizeMode.MIDDLE);
 			item.connect('activate', () => {
 				control.set_default_sink(sink);
 			});
@@ -89,6 +92,7 @@ const AudioInputSubMenu = GObject.registerClass({
 		//Unless there is at least one item here, no 'open' will be emitted...
 		let item = new PopupMenu.PopupMenuItem('Connecting...');
 		this.menu.addMenuItem(item);
+		this.label.clutter_text.set_ellipsize(Pango.EllipsizeMode.MIDDLE);
 	}
 
 	_updateDefaultSource() {
@@ -114,6 +118,7 @@ const AudioInputSubMenu = GObject.registerClass({
 				continue;
 			}
 			item = new PopupMenu.PopupMenuItem(source.get_description());
+			item.label.clutter_text.set_ellipsize(Pango.EllipsizeMode.MIDDLE);
 			item.connect('activate', () => {
 				control.set_default_source(source);
 			});


### PR DESCRIPTION
My audiodevices have rater long names, to it's impossible to distinguish them:
![grafik](https://user-images.githubusercontent.com/758478/150943864-758cf908-a9f8-4ce3-b185-4b58cf7e2a58.png)

this patch sets Pango.EllipsizeMode.MIDDLE so text is ommited in the middle, instead of the end

![grafik](https://user-images.githubusercontent.com/758478/150944175-ab204e6f-94b9-40b2-82c0-44884046a527.png)

